### PR TITLE
pass build-args through to docker/build-push-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ jobs:
 | ------ | --------- | ------- |------------ |
 | `image`  | yes | | Full Docker image name to build and push, including the registry, repository and tag |
 | `file` | no | `Dockerfile` | Path to the `Dockerfile` to build |
+| `build-args` | no | `[]` | `build-args` to pass to `docker/build-push-action` |
 | `service_account` | no | `github-actions@buildable-production.iam.gserviceaccount.com` | GCP service account used to authenticate to Google Cloud |
 | `workload_identity_provider` | no | `projects/157041665647/locations/global/workloadIdentityPools/github-actions/providers/github-actions` | GCP workload identity provider used to authenticate to Google Cloud |

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     required: false
     default: Dockerfile
     description: Path to the `Dockerfile` to build
+  build-args:
+    required: false
+    default: []
+    desription: `build-args` to pass to `docker/build-push-action`
   service_account:
     required: false
     default: github-actions@buildable-production.iam.gserviceaccount.com
@@ -47,5 +51,6 @@ runs:
       uses: docker/build-push-action@v4
       with:
         file: ${{ inputs.file }}
+        build-args: ${{ inputs.build-args }}
         push: true
         tags: ${{ inputs.image }}


### PR DESCRIPTION
All the `Dockerfile`s in https://github.com/event-cloud/event-rs are identical except for the executable name. Instead of copying the file each time, I want to switch to using the same `Dockerfile` but passing the executable name in as a `build-arg`. To do this I would need to be able to pass the `build-arg`s up to this action.