### PR TITLE
Fix typo and don't start line with reserved char

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ jobs:
 | ------ | --------- | ------- |------------ |
 | `image`  | yes | | Full Docker image name to build and push, including the registry, repository and tag |
 | `file` | no | `Dockerfile` | Path to the `Dockerfile` to build |
-| `build-args` | no | `[]` | `build-args` to pass to `docker/build-push-action` |
+| `build-args` | no | `[]` | The `build-args` to pass to `docker/build-push-action` |
 | `service_account` | no | `github-actions@buildable-production.iam.gserviceaccount.com` | GCP service account used to authenticate to Google Cloud |
 | `workload_identity_provider` | no | `projects/157041665647/locations/global/workloadIdentityPools/github-actions/providers/github-actions` | GCP workload identity provider used to authenticate to Google Cloud |

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
   build-args:
     required: false
     default: []
-    desription: `build-args` to pass to `docker/build-push-action`
+    description: The `build-args` to pass to `docker/build-push-action`
   service_account:
     required: false
     default: github-actions@buildable-production.iam.gserviceaccount.com


### PR DESCRIPTION
GitHub Actions VSCode extension doesn't seem to like starting a description with the ` character.
```
[Error - 12:23:50 PM] Request textDocument/hover failed.
  Message: Request textDocument/hover failed with message: Plain value cannot start with reserved character ` at line 15, column 17:

    desription: `build-args` to pass to `docker/build-push-action`
```