### PR TITLE
Use string instead of sequence for build-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ jobs:
 | ------ | --------- | ------- |------------ |
 | `image`  | yes | | Full Docker image name to build and push, including the registry, repository and tag |
 | `file` | no | `Dockerfile` | Path to the `Dockerfile` to build |
-| `build-args` | no | `[]` | The `build-args` to pass to `docker/build-push-action` |
+| `build-args` | no | `""` | The `build-args` to pass to `docker/build-push-action` |
 | `service_account` | no | `github-actions@buildable-production.iam.gserviceaccount.com` | GCP service account used to authenticate to Google Cloud |
 | `workload_identity_provider` | no | `projects/157041665647/locations/global/workloadIdentityPools/github-actions/providers/github-actions` | GCP workload identity provider used to authenticate to Google Cloud |

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
     description: Path to the `Dockerfile` to build
   build-args:
     required: false
-    default: []
+    default: ""
     description: The `build-args` to pass to `docker/build-push-action`
   service_account:
     required: false


### PR DESCRIPTION
Apparently a `List` according to the docs is just `key=value,key2=value2` instead of a yaml list.