### PR TITLE
Revert Use inline caching

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -59,5 +59,5 @@ runs:
         secrets: ${{ inputs.secrets }}
         push: true
         tags: ${{ inputs.image }}
-        cache-from: type=registry,ref=${{ steps.get_docker_registry.outputs.registry }}/${{ inputs.image }}
-        cache-to: type=inline
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
Inline caching is not useful for our Rust dockerfiles, because they use multi stage builds.
Revert to using the experimental github actions cache to see if it takes advantage of earlier builds stages.