### PR TITLE
Setup buildx before building and upgrade push action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,8 +51,11 @@ runs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         file: ${{ inputs.file }}
         build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
Caching fails with `docker` driver. Using `docker/setup-buildx-action@v3` sets up `docker-container` driver which allows us to utilize multi-stage caching. https://docs.docker.com/build/drivers/

This solution is taken from the example here https://github.com/docker/build-push-action#usage